### PR TITLE
Remove cssify as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,16 +26,6 @@
     "develop": "done-serve --static --develop --port 8080"
   },
   "main": "dist/cjs/can-connect-ndjson",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
   "keywords": [],
   "steal": {
     "main": "can-connect-ndjson",
@@ -53,8 +43,7 @@
     "can-connect": "^1.3.6",
     "can-define": "^1.0.16",
     "can-ndjson-stream": "0.0.0",
-    "can-util": "^3.3.0",
-    "cssify": "^0.6.0"
+    "can-util": "^3.3.0"
   },
   "devDependencies": {
     "can-stache": "^3.0.19",


### PR DESCRIPTION
It’s not used and it breaks Browserify usage.